### PR TITLE
Simplify DC coding.

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -80,8 +80,6 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
   auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
     modular_frame_encoder->AddVarDCTDC(
         dc, group_index,
-        enc_state->cparams.butteraugli_distance >= 2.0f &&
-            enc_state->cparams.speed_tier < SpeedTier::kFalcon,
         enc_state, /*jpeg_transcode=*/false);
   };
   JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, shared.frame_dim.num_dc_groups,

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -715,8 +715,8 @@ class LossyFrameEncoder {
     shared.frame_header.UpdateFlag(false, FrameHeader::kUseDcFrame);
     auto compute_dc_coeffs = [&](const uint32_t group_index,
                                  size_t /* thread */) {
-      modular_frame_encoder->AddVarDCTDC(dc, group_index, /*nl_dc=*/false,
-                                         enc_state_, /*jpeg_transcode=*/true);
+      modular_frame_encoder->AddVarDCTDC(dc, group_index, enc_state_,
+                                         /*jpeg_transcode=*/true);
       modular_frame_encoder->AddACMetadata(group_index, /*jpeg_transcode=*/true,
                                            enc_state_);
     };

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -43,7 +43,7 @@ class ModularFrameEncoder {
   // input DC image, not quantized; the group is specified by `group_index`, and
   // `nl_dc` decides whether to apply a near-lossless processing to the DC or
   // not.
-  void AddVarDCTDC(const Image3F& dc, size_t group_index, bool nl_dc,
+  void AddVarDCTDC(const Image3F& dc, size_t group_index,
                    PassesEncoderState* enc_state, bool jpeg_transcode);
   // Creates a modular image for the AC metadata of the given group
   // (`group_index`).

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -358,7 +358,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 34500u, 18);
+                               2.0f, 34500u, 18.5);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -377,7 +377,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
 
   CodecInOut io2;
   EXPECT_FALSE(io.Main().IsGray());
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55000u);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55100u);
   EXPECT_TRUE(io2.Main().IsGray());
 
   // Convert original to grayscale here, because TransformTo refuses to
@@ -413,7 +413,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.speed_tier = SpeedTier::kSquirrel;
 
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 450800u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 460200u);
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -1416,7 +1416,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444)) {
   ThreadPoolInternal pool(8);
   const PaddedBytes orig = ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   // JPEG size is 696,659 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 570000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 582000u);
 }
 
 #if JPEGXL_ENABLE_JPEG
@@ -1539,7 +1539,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
   ThreadPoolInternal pool(8);
   const PaddedBytes orig = ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   // JPEG size is 546,797 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 460000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 461000u);
 }
 
 TEST(JxlTest,
@@ -1548,7 +1548,7 @@ TEST(JxlTest,
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_luma_subsample.jpg");
   // JPEG size is 400,724 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 330000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 334000u);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
@@ -1557,14 +1557,14 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 570000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 582000u);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression422)) {
   ThreadPoolInternal pool(8);
   const PaddedBytes orig = ReadTestData("jxl/flower/flower.png.im_q85_422.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 500000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 508000u);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression440)) {
@@ -1589,7 +1589,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420Progr)) {
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 460000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 461000u);
 }
 
 }  // namespace


### PR DESCRIPTION
No nl_dc mode and use gradient predictor instead of weighted.

Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2685293    1.6188106   1.640  11.226   1.68643689   0.60031889  0.971802597092      0
jxl:d4          13270  1005279    0.6060256   1.709   6.196   4.89369059   1.50839606  0.914126650000      0
Aggregate:      13270  1643006    0.9904750   1.674   8.340   2.87278616   0.95158743  0.942523555431      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2702757    1.6293387   1.550  12.177   1.68643689   0.60031889  0.978122786567      0
jxl:d4          13270   987800    0.5954885   1.942   6.852   4.95230675   1.52608424  0.908765642253      0
Aggregate:      13270  1633947    0.9850139   1.735   9.135   2.88993993   0.95715056  0.942806651619      0
```