### PR TITLE
Simplify entropy coding: no uint config selection, no mtf.

### DIFF
--- a/lib/jxl/ac_strategy_test.cc
+++ b/lib/jxl/ac_strategy_test.cc
@@ -194,8 +194,5 @@ HWY_TARGET_INSTANTIATE_TEST_SUITE_P_T(AcStrategyDownsample,
 
 TEST_P(AcStrategyDownsample, Test) { Run(); }
 
-class AcStrategyTargetTest : public ::hwy::TestWithParamTarget {};
-HWY_TARGET_INSTANTIATE_TEST_SUITE_P(AcStrategyTargetTest);
-
 }  // namespace
 }  // namespace jxl

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -102,21 +102,16 @@ struct Token {
   uint32_t value;
 };
 
-// Returns an estimate of the number of bits required to encode the given
-// histogram (header bits plus data bits).
-float ANSPopulationCost(const ANSHistBin* data, size_t alphabet_size);
-
 // Apply context clustering, compute histograms and encode them. Returns an
 // estimate of the total bits used for encoding the stream. If `writer` ==
 // nullptr, the bit estimate will not take into account the context map (which
 // does not get written if `num_contexts` == 1).
-size_t BuildAndEncodeHistograms(const HistogramParams& params,
-                                size_t num_contexts,
-                                std::vector<std::vector<Token>>& tokens,
-                                EntropyEncodingData* codes,
-                                std::vector<uint8_t>* context_map,
-                                BitWriter* writer, size_t layer,
-                                AuxOut* aux_out);
+void BuildAndEncodeHistograms(const HistogramParams& params,
+                              size_t num_contexts,
+                              std::vector<std::vector<Token>>& tokens,
+                              EntropyEncodingData* codes,
+                              std::vector<uint8_t>* context_map,
+                              BitWriter* writer, size_t layer, AuxOut* aux_out);
 
 // Write the tokens to a string.
 void WriteTokens(const std::vector<Token>& tokens,

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -20,7 +20,6 @@ struct HistogramParams {
   enum class ClusteringType {
     kFastest,  // Only 4 clusters.
     kFast,
-    kBest,
   };
 
   enum class HybridUintMethod {
@@ -28,7 +27,6 @@ struct HistogramParams {
     k000,         // force the fastest option.
     kFast,        // just try a couple of options.
     kContextMap,  // fast choice for ctx map.
-    kBest,
   };
 
   enum class LZ77Method {

--- a/lib/jxl/enc_cluster.h
+++ b/lib/jxl/enc_cluster.h
@@ -42,9 +42,6 @@ struct Histogram {
     }
     total_count_ += other.total_count_;
   }
-  float PopulationCost() const {
-    return ANSPopulationCost(data_.data(), data_.size());
-  }
   float ShannonEntropy() const;
 
   std::vector<ANSHistBin> data_;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -287,7 +287,7 @@ TEST(EncodeTest, frame_settingsTest) {
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3600, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3750, false);
     EXPECT_EQ(true, enc->last_used_cparams.IsLossless());
   }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -377,7 +377,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
 
   CodecInOut io2;
   EXPECT_FALSE(io.Main().IsGray());
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55100u);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55500u);
   EXPECT_TRUE(io2.Main().IsGray());
 
   // Convert original to grayscale here, because TransformTo refuses to
@@ -1548,7 +1548,7 @@ TEST(JxlTest,
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_luma_subsample.jpg");
   // JPEG size is 400,724 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 334000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 334500u);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {


### PR DESCRIPTION
Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2702757    1.6293387   1.550  12.177   1.68643689   0.60031889  0.978122786567      0
jxl:d4          13270   987800    0.5954885   1.942   6.852   4.95230675   1.52608424  0.908765642253      0
Aggregate:      13270  1633947    0.9850139   1.735   9.135   2.88993993   0.95715056  0.942806651619      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2705530    1.6310104   1.445   9.765   1.68643689   0.60031889  0.979126330166      0
jxl:d4          13270   988471    0.5958930   1.709   5.960   4.95230675   1.52608424  0.909382955217      0
Aggregate:      13270  1635340    0.9858538   1.572   7.629   2.88993993   0.95715056  0.943610510570      0
```