### PR TITLE
Remove search for optimal ans histogram shifts.

### DIFF
--- a/lib/jxl/ans_test.cc
+++ b/lib/jxl/ans_test.cc
@@ -157,34 +157,6 @@ TEST(ANSTest, RandomUnbalancedStreamRoundtripBig) {
   RoundtripRandomUnbalancedStream(ANS_MAX_ALPHABET_SIZE);
 }
 
-TEST(ANSTest, UintConfigRoundtrip) {
-  for (size_t log_alpha_size = 5; log_alpha_size <= 8; log_alpha_size++) {
-    std::vector<HybridUintConfig> uint_config, uint_config_dec;
-    for (size_t i = 0; i < log_alpha_size; i++) {
-      for (size_t j = 0; j <= i; j++) {
-        for (size_t k = 0; k <= i - j; k++) {
-          uint_config.emplace_back(i, j, k);
-        }
-      }
-    }
-    uint_config.emplace_back(log_alpha_size, 0, 0);
-    uint_config_dec.resize(uint_config.size());
-    BitWriter writer;
-    BitWriter::Allotment allotment(&writer, 10 * uint_config.size());
-    EncodeUintConfigs(uint_config, &writer, log_alpha_size);
-    ReclaimAndCharge(&writer, &allotment, 0, nullptr);
-    writer.ZeroPadToByte();
-    BitReader br(writer.GetSpan());
-    EXPECT_TRUE(DecodeUintConfigs(log_alpha_size, &uint_config_dec, &br));
-    EXPECT_TRUE(br.Close());
-    for (size_t i = 0; i < uint_config.size(); i++) {
-      EXPECT_EQ(uint_config[i].split_token, uint_config_dec[i].split_token);
-      EXPECT_EQ(uint_config[i].msb_in_token, uint_config_dec[i].msb_in_token);
-      EXPECT_EQ(uint_config[i].lsb_in_token, uint_config_dec[i].lsb_in_token);
-    }
-  }
-}
-
 void TestCheckpointing(bool ans, bool lz77) {
   std::vector<std::vector<Token>> input_values(1);
   for (size_t i = 0; i < 1024; i++) {

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -22,22 +22,9 @@ struct HistogramParams {
     kFast,
   };
 
-  enum class HybridUintMethod {
-    kNone,        // just use kHybridUint420Config.
-    k000,         // force the fastest option.
-    kFast,        // just try a couple of options.
-    kContextMap,  // fast choice for ctx map.
-  };
-
   enum class LZ77Method {
     kNone,     // do not try lz77.
     kRLE,      // only try doing RLE.
-  };
-
-  enum class ANSHistogramStrategy {
-    kFast,         // Only try some methods, early exit.
-    kApproximate,  // Only try some methods.
-    kPrecise,      // Try all methods.
   };
 
   HistogramParams() = default;
@@ -50,10 +37,7 @@ struct HistogramParams {
   }
 
   ClusteringType clustering = ClusteringType::kFast;
-  HybridUintMethod uint_method = HybridUintMethod::kNone;
   LZ77Method lz77_method = LZ77Method::kRLE;
-  ANSHistogramStrategy ans_histogram_strategy =
-      ANSHistogramStrategy::kApproximate;
   std::vector<size_t> image_widths;
   size_t max_histograms = ~0;
 };

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -107,7 +107,7 @@ void FastClusterHistograms(const std::vector<Histogram>& in,
     }
   }
 
-  constexpr float kMinDistanceForDistinct = 48.0f;
+  constexpr float kMinDistanceForDistinct = 64.0f;
   while (out->size() < max_histograms) {
     (*histogram_symbols)[largest_idx] = out->size();
     out->push_back(in[largest_idx]);

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -39,7 +39,6 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
     tokens[0].emplace_back(0, context_map[i]);
   }
   HistogramParams params;
-  params.uint_method = HistogramParams::HybridUintMethod::kContextMap;
   writer->Write(1, 0);
   writer->Write(1, 0);  // Don't use MTF.
   BuildAndEncodeHistograms(params, 1, tokens, &codes, &dummy_context_map,

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1112,10 +1112,6 @@ Status ModularFrameEncoder::EncodeGlobalInfo(BitWriter* writer,
   // Write tree
   HistogramParams params;
   params.clustering = HistogramParams::ClusteringType::kFast;
-  params.ans_histogram_strategy =
-      cparams_.speed_tier > SpeedTier::kThunder
-          ? HistogramParams::ANSHistogramStrategy::kFast
-          : HistogramParams::ANSHistogramStrategy::kApproximate;
   params.lz77_method =
       cparams_.decoding_speed_tier >= 3 && cparams_.modular_mode
           ? HistogramParams::LZ77Method::kRLE

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -227,7 +227,7 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
 
 void VerifyFrameEncoding(JxlEncoder* enc,
                          const JxlEncoderFrameSettings* frame_settings) {
-  VerifyFrameEncoding(63, 129, enc, frame_settings, 2600,
+  VerifyFrameEncoding(63, 129, enc, frame_settings, 2700,
                       /*lossy_use_original_profile=*/false);
 }
 
@@ -242,13 +242,13 @@ TEST(EncodeTest, EncoderResetTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());
   VerifyFrameEncoding(50, 200, enc.get(),
-                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4300,
+                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4500,
                       false);
   // Encoder should become reusable for a new image from scratch after using
   // reset.
   JxlEncoderReset(enc.get());
   VerifyFrameEncoding(157, 77, enc.get(),
-                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 2300,
+                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 2500,
                       false);
 }
 
@@ -287,7 +287,7 @@ TEST(EncodeTest, frame_settingsTest) {
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3750, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4100, false);
     EXPECT_EQ(true, enc->last_used_cparams.IsLossless());
   }
 
@@ -297,7 +297,7 @@ TEST(EncodeTest, frame_settingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(frame_settings, 0.5));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3000, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3100, false);
     EXPECT_EQ(0.5, enc->last_used_cparams.butteraugli_distance);
   }
 
@@ -467,7 +467,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4100, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4200, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -283,7 +283,7 @@ TEST(JxlTest, RoundtripResample8) {
   CompressParams cparams;
   cparams.resampling = 8;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, pool, &io2), 2100u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, pool, &io2), 2150u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
               IsSlightlyBelow(50));
@@ -377,7 +377,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
 
   CodecInOut io2;
   EXPECT_FALSE(io.Main().IsGray());
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55500u);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 56000u);
   EXPECT_TRUE(io2.Main().IsGray());
 
   // Convert original to grayscale here, because TransformTo refuses to
@@ -413,7 +413,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.speed_tier = SpeedTier::kSquirrel;
 
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 460200u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 461000u);
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -554,7 +554,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.butteraugli_distance = 1.0;
 
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, pool, &io2), 900u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, pool, &io2), 920u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
               IsSlightlyBelow(1.2));
@@ -1539,7 +1539,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
   ThreadPoolInternal pool(8);
   const PaddedBytes orig = ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   // JPEG size is 546,797 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 461000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 461500u);
 }
 
 TEST(JxlTest,
@@ -1557,7 +1557,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 582000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 583000u);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression422)) {
@@ -1589,7 +1589,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420Progr)) {
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_LE(RoundtripJpeg(orig, &pool), 461000u);
+  EXPECT_LE(RoundtripJpeg(orig, &pool), 461500u);
 }
 
 }  // namespace

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -164,7 +164,7 @@ TEST(ModularTest, RoundtripLossy16) {
   io.metadata.m.color_encoding = ColorEncoding::SRGB();
 
   compressed_size = Roundtrip(&io, cparams, {}, pool, &io_out);
-  EXPECT_LE(compressed_size, 300u);
+  EXPECT_LE(compressed_size, 310u);
   cparams.ba_params.intensity_target = 80.0f;
   EXPECT_THAT(ButteraugliDistance(io, io_out, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),


### PR DESCRIPTION
Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2703866    1.6300072   3.101  20.774   1.68643689   0.60031889  0.978524131627      0
jxl:d4          13270   986748    0.5948543   3.589  11.849   4.95230675   1.52608424  0.907797813284      0
Aggregate:      13270  1633412    0.9846913   3.336  15.689   2.88993993   0.95715056  0.942497780866      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2715181    1.6368284   3.105  20.554   1.68643689   0.60031889  0.982619009313      0
jxl:d4          13270   995088    0.5998820   3.621  12.138   4.95230675   1.52608424  0.915470525833      0
Aggregate:      13270  1643729    0.9909107   3.353  15.795   2.88993993   0.95715056  0.948450705704      0
```