### PR TITLE
Remove adaptive dc smoothing and dc dequantization.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -110,7 +110,7 @@ Status MakeFrameHeader(const CompressParams& cparams,
   JXL_RETURN_IF_ERROR(LoopFilterFromParams(cparams, frame_header));
 
   frame_header->dc_level = 0;
-
+  frame_header->flags |= FrameHeader::kSkipAdaptiveDCSmoothing;
   frame_header->frame_origin = ib.origin;
   frame_header->frame_size.xsize = ib.xsize();
   frame_header->frame_size.ysize = ib.ysize();
@@ -205,10 +205,6 @@ class LossyFrameEncoder {
     JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, shared.frame_dim.num_dc_groups,
                                   ThreadPool::NoInit, compute_dc_coeffs,
                                   "Compute DC coeffs"));
-    // TODO(veluca): this is only useful in tests and if inspection is enabled.
-    if (!(shared.frame_header.flags & FrameHeader::kSkipAdaptiveDCSmoothing)) {
-      AdaptiveDCSmoothing(shared.quantizer.MulDC(), &shared.dc_storage, pool);
-    }
     auto compute_ac_meta = [&](int group_index, int /* thread */) {
       modular_frame_encoder->AddACMetadata(group_index, &shared);
     };

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -476,11 +476,6 @@ void ModularFrameEncoder::AddVarDCTDC(const Image3F& dc, size_t group_index,
       }
     }
   }
-
-  DequantDC(r, &shared->dc_storage, &shared->quant_dc,
-            stream_images_[stream_id], shared->quantizer.MulDC(), 1.0,
-            shared->cmap.DCFactors(), shared->frame_header.chroma_subsampling,
-            shared->block_ctx_map);
 }
 
 void ModularFrameEncoder::AddACMetadata(size_t group_index,

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -403,8 +403,6 @@ void VerifyRoundtripCompression(
       ButteraugliDistance(original_io, decoded_io, ba, jxl::GetJxlCms(),
                           /*distmap=*/nullptr, nullptr);
   EXPECT_LE(butteraugli_score, 2.0f);
-  JxlPixelFormat extra_channel_output_pixel_format = output_pixel_format;
-  extra_channel_output_pixel_format.num_channels = 1;
   for (auto& extra_channel : extra_channel_decoded_bytes) {
     EXPECT_EQ(extra_channel.size(), extra_channel_bytes.size());
   }


### PR DESCRIPTION
Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2698702    1.6268942   3.077  17.755   1.68383265   0.59768853  0.972375975660      0
jxl:d4          13270   978826    0.5900786   3.488   8.380   4.79905510   1.53513401  0.905849733001      0
Aggregate:      13270  1625288    0.9797936   3.276  12.198   2.84267579   0.95787890  0.938523584109      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2698733    1.6269128   2.914  17.795   1.68391395   0.59700273  0.971271413437      0
jxl:d4          13270   978857    0.5900973   3.359   8.389   4.79905367   1.53140292  0.903676711144      0
Aggregate:      13270  1625323    0.9798147   3.129  12.218   2.84274399   0.95616511  0.936864641516      0
```