### PR TITLE
Remove quant error diffusion.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -167,9 +167,8 @@ class LossyFrameEncoder {
       shared.frame_header.x_qm_scale++;
     }
     DefaultEncoderHeuristics heuristics;
-    JXL_RETURN_IF_ERROR(
-        heuristics.LossyFrameHeuristics(enc_state_, modular_frame_encoder,
-                                        linear, opsin, cms_, pool_, aux_out_));
+    JXL_RETURN_IF_ERROR(heuristics.LossyFrameHeuristics(
+        enc_state_, linear, opsin, cms_, pool_, aux_out_));
 
     enc_state_->histogram_idx.resize(shared.frame_dim.num_groups);
 
@@ -277,8 +276,7 @@ class LossyFrameEncoder {
     return true;
   }
 
-  Status EncodeGlobalACInfo(BitWriter* writer,
-                            ModularFrameEncoder* modular_frame_encoder) {
+  Status EncodeGlobalACInfo(BitWriter* writer) {
     {
       BitWriter::Allotment allotment(writer, 1024);
       writer->Write(1, 1);  // all default quant matrices
@@ -472,8 +470,8 @@ Status EncodeFrame(const CompressParams& cparams, const FrameInfo& frame_info,
                                 resize_aux_outs, process_dc_group,
                                 "EncodeDCGroup"));
 
-  JXL_RETURN_IF_ERROR(lossy_frame_encoder.EncodeGlobalACInfo(
-      get_output(global_ac_index), modular_frame_encoder.get()));
+  JXL_RETURN_IF_ERROR(
+      lossy_frame_encoder.EncodeGlobalACInfo(get_output(global_ac_index)));
 
   std::atomic<int> num_errors{0};
   const auto process_group = [&](const uint32_t group_index,

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -24,9 +24,9 @@
 namespace jxl {
 
 Status DefaultEncoderHeuristics::LossyFrameHeuristics(
-    PassesEncoderState* enc_state, ModularFrameEncoder* modular_frame_encoder,
-    const ImageBundle* original_pixels, Image3F* opsin,
-    const JxlCmsInterface& cms, ThreadPool* pool, AuxOut* aux_out) {
+    PassesEncoderState* enc_state, const ImageBundle* original_pixels,
+    Image3F* opsin, const JxlCmsInterface& cms, ThreadPool* pool,
+    AuxOut* aux_out) {
   PROFILER_ZONE("JxlLossyFrameHeuristics uninstrumented");
 
   CompressParams& cparams = enc_state->cparams;

--- a/lib/jxl/enc_heuristics.h
+++ b/lib/jxl/enc_heuristics.h
@@ -34,16 +34,16 @@ class EncoderHeuristics {
   // `opsin` image by applying Gaborish, and doing other modifications if
   // necessary. `pool` is used for running the computations on multiple threads.
   // `aux_out` collects statistics and can be used to print debug images.
-  virtual Status LossyFrameHeuristics(
-      PassesEncoderState* enc_state, ModularFrameEncoder* modular_frame_encoder,
-      const ImageBundle* original_pixels, Image3F* opsin,
-      const JxlCmsInterface& cms, ThreadPool* pool, AuxOut* aux_out) = 0;
+  virtual Status LossyFrameHeuristics(PassesEncoderState* enc_state,
+                                      const ImageBundle* original_pixels,
+                                      Image3F* opsin,
+                                      const JxlCmsInterface& cms,
+                                      ThreadPool* pool, AuxOut* aux_out) = 0;
 };
 
 class DefaultEncoderHeuristics : public EncoderHeuristics {
  public:
   Status LossyFrameHeuristics(PassesEncoderState* enc_state,
-                              ModularFrameEncoder* modular_frame_encoder,
                               const ImageBundle* original_pixels,
                               Image3F* opsin, const JxlCmsInterface& cms,
                               ThreadPool* pool, AuxOut* aux_out) override;


### PR DESCRIPTION
Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2698733    1.6269128   3.128  18.539   1.68391395   0.59700273  0.971271413437      0
jxl:d4          13270   978857    0.5900973   3.538   8.935   4.79905367   1.53140292  0.903676711144      0
Aggregate:      13270  1625323    0.9798147   3.327  12.870   2.84274399   0.95616511  0.936864641516      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2684273    1.6181957   3.285  16.598   1.68390751   0.59856118  0.968589148494      0
jxl:d4          13270   974024    0.5871837   3.633   8.089   4.79908895   1.53634963  0.902119535776      0
Aggregate:      13270  1616956    0.9747709   3.455  11.587   2.84274901   0.95895737  0.934763709713      0
```