### PR TITLE
Add a simple encoder function taking a linear sRGB Image3F.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,3 +453,6 @@ endif ()
 
 # Binary tools
 add_subdirectory(tools)
+
+# Encoder only sources
+add_subdirectory(encoder)

--- a/encoder/CMakeLists.txt
+++ b/encoder/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) the JPEG XL Project Authors.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+add_library(jxl_tiny STATIC EXCLUDE_FROM_ALL
+  read_pfm.cc
+)
+target_compile_options(jxl_tiny PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
+target_include_directories(jxl_tiny PUBLIC "${PROJECT_SOURCE_DIR}")
+target_link_libraries(jxl_tiny jxl-static jxl_tool)
+
+
+add_executable(cjxl_tiny cjxl_main.cc)
+target_link_libraries(cjxl_tiny jxl_tiny)

--- a/encoder/cjxl_main.cc
+++ b/encoder/cjxl_main.cc
@@ -1,0 +1,69 @@
+// Copyright (c) the JPEG XL Project Authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <stdio.h>
+
+#include "encoder/read_pfm.h"
+#include "lib/jxl/base/printf_macros.h"
+#include "lib/jxl/enc_file.h"
+#include "lib/jxl/image.h"
+#include "tools/cmdline.h"
+#include "tools/file_io.h"
+
+namespace {
+struct CompressArgs {
+  void AddCommandLineOptions(jpegxl::tools::CommandLineParser* cmdline) {
+    cmdline->AddPositionalOption("INPUT", /* required = */ true,
+                                 "the input is PFM in linear sRGB colorspace",
+                                 &file_in);
+    cmdline->AddPositionalOption(
+        "OUTPUT", /* required = */ false,
+        "the compressed JXL output file (can be omitted for benchmarking)",
+        &file_out);
+    cmdline->AddOptionValue('d', "distance", "maxError",
+                            "Target butteraugli distance.", &distance,
+                            jpegxl::tools::ParseFloat);
+  }
+  const char* file_in = nullptr;
+  const char* file_out = nullptr;
+  float distance = 1.0;
+};
+}  // namespace
+
+int main(int argc, char** argv) {
+  jpegxl::tools::CommandLineParser cmdline;
+  CompressArgs args;
+  args.AddCommandLineOptions(&cmdline);
+
+  if (!cmdline.Parse(argc, const_cast<const char**>(argv)) || !args.file_in) {
+    fprintf(stderr, "Use '%s -h' for more information\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  jxl::Image3F image;
+  if (!jxl::ReadPFM(args.file_in, &image)) {
+    fprintf(stderr, "Error reading PFM input file.\n");
+    return EXIT_FAILURE;
+  }
+
+  fprintf(stderr, "Read %" PRIuS "x%" PRIuS " pixels input image.\n",
+          image.xsize(), image.ysize());
+
+  std::vector<uint8_t> output;
+  if (!jxl::EncodeFile(image, args.distance, &output)) {
+    fprintf(stderr, "Encoding failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  fprintf(stderr, "Compressed to %" PRIuS " bytes.\n", output.size());
+
+  if (args.file_out && !jpegxl::tools::WriteFile(args.file_out, output)) {
+    fprintf(stderr, "Failed to write to output file %s\n", args.file_out);
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/encoder/read_pfm.cc
+++ b/encoder/read_pfm.cc
@@ -1,0 +1,199 @@
+// Copyright (c) the JPEG XL Project Authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "encoder/read_pfm.h"
+
+#include "tools/file_io.h"
+
+namespace jxl {
+
+namespace {
+class Parser {
+ public:
+  explicit Parser(const uint8_t* data, const size_t len)
+      : pos_(data), end_(data + len) {}
+
+  // Sets "pos" to the first non-header byte/pixel on success.
+  bool ParseHeaderPFM(const uint8_t** pos, size_t* xsize, size_t* ysize,
+                      bool* big_endian) {
+    if (pos_[0] != 'P' || pos_[1] != 'F') return false;
+    pos_ += 2;
+
+    double scale;
+    if (!SkipSingleWhitespace() || !ParseUnsigned(xsize) || !SkipBlank() ||
+        !ParseUnsigned(ysize) || !SkipSingleWhitespace() ||
+        !ParseSigned(&scale) || !SkipSingleWhitespace()) {
+      return false;
+    }
+
+    // The scale has no meaning as multiplier, only its sign is used to
+    // indicate endianness. All software expects nominal range 0..1.
+    if (scale == 0.0 || std::abs(scale) != 1.0) {
+      fprintf(stderr, "PFM: bad scale factor value.\n");
+      return false;
+    }
+    *big_endian = scale > 0.0;
+
+    *pos = pos_;
+    return true;
+  }
+
+  bool ParseUnsigned(size_t* number) {
+    if (pos_ == end_) {
+      fprintf(stderr, "PNM: reached end before number.\n");
+      return false;
+    }
+    if (!IsDigit(*pos_)) {
+      fprintf(stderr, "PNM: expected unsigned number.\n");
+      return false;
+    }
+    *number = 0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    return true;
+  }
+
+  bool ParseSigned(double* number) {
+    if (pos_ == end_) {
+      fprintf(stderr, "PNM: reached end before signed.\n");
+      return false;
+    }
+    if (*pos_ != '-' && *pos_ != '+' && !IsDigit(*pos_)) {
+      fprintf(stderr, "PNM: expected signed number.\n");
+      return false;
+    }
+
+    // Skip sign
+    const bool is_neg = *pos_ == '-';
+    if (is_neg || *pos_ == '+') {
+      ++pos_;
+      if (pos_ == end_) {
+        fprintf(stderr, "PNM: reached end before digits.\n");
+        return false;
+      }
+    }
+
+    // Leading digits
+    *number = 0.0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    // Decimal places?
+    if (pos_ < end_ && *pos_ == '.') {
+      ++pos_;
+      double place = 0.1;
+      while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+        *number += (*pos_ - '0') * place;
+        place *= 0.1;
+        ++pos_;
+      }
+    }
+
+    if (is_neg) *number = -*number;
+    return true;
+  }
+
+ private:
+  static bool IsDigit(const uint8_t c) { return '0' <= c && c <= '9'; }
+  static bool IsLineBreak(const uint8_t c) { return c == '\r' || c == '\n'; }
+  static bool IsWhitespace(const uint8_t c) {
+    return IsLineBreak(c) || c == '\t' || c == ' ';
+  }
+
+  bool SkipBlank() {
+    if (pos_ == end_) {
+      fprintf(stderr, "PNM: reached end before blank.\n");
+      return false;
+    }
+    const uint8_t c = *pos_;
+    if (c != ' ' && c != '\n') {
+      fprintf(stderr, "PNM: expected blank.\n");
+      return false;
+    }
+    ++pos_;
+    return true;
+  }
+
+  bool SkipSingleWhitespace() {
+    if (pos_ == end_) {
+      fprintf(stderr, "PNM: reached end before whitespace.\n");
+      return false;
+    }
+    if (!IsWhitespace(*pos_)) {
+      fprintf(stderr, "PNM: expected whitespace.\n");
+      return false;
+    }
+    ++pos_;
+    return true;
+  }
+
+  const uint8_t* pos_;
+  const uint8_t* const end_;
+};
+
+#if JXL_COMPILER_MSVC
+#define JXL_BSWAP32(x) _byteswap_ulong(x)
+#else
+#define JXL_BSWAP32(x) __builtin_bswap32(x)
+#endif
+
+inline float BSwapFloat(float x) {
+  uint32_t u;
+  memcpy(&u, &x, 4);
+  uint32_t uswap = JXL_BSWAP32(u);
+  float xswap;
+  memcpy(&xswap, &uswap, 4);
+  return xswap;
+}
+
+}  // namespace
+
+bool ReadPFM(const char* fn, Image3F* image) {
+  std::vector<uint8_t> data;
+  if (!jpegxl::tools::ReadFile(fn, &data)) {
+    fprintf(stderr, "Could not read %s\n", fn);
+    return false;
+  }
+  if (data.size() < 2) {
+    fprintf(stderr, "PFM file too small.\n");
+    return false;
+  }
+
+  Parser parser(data.data(), data.size());
+  size_t xsize, ysize;
+  bool big_endian;
+  const uint8_t* pos = nullptr;
+  if (!parser.ParseHeaderPFM(&pos, &xsize, &ysize, &big_endian)) {
+    return false;
+  }
+
+  Image3F img(xsize, ysize);
+  const float* input = reinterpret_cast<const float*>(pos);
+  const size_t stride = xsize * 3;
+  for (size_t y = 0; y < ysize; ++y) {
+    size_t y_in = ysize - 1 - y;
+    const float* row_in = &input[y_in * stride];
+    for (size_t c = 0; c < 3; ++c) {
+      float* row_out = img.PlaneRow(c, y);
+      for (size_t x = 0; x < xsize; ++x) {
+        row_out[x] = row_in[x * 3 + c];
+        if (big_endian) row_out[x] = BSwapFloat(row_out[x]);
+      }
+    }
+  }
+
+  *image = std::move(img);
+  return true;
+}
+
+}  // namespace jxl

--- a/encoder/read_pfm.h
+++ b/encoder/read_pfm.h
@@ -1,0 +1,18 @@
+// Copyright (c) the JPEG XL Project Authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef ENCODER_READ_PFM_H_
+#define ENCODER_READ_PFM_H_
+
+#include "lib/jxl/image.h"
+
+namespace jxl {
+
+bool ReadPFM(const char* fn, jxl::Image3F* image);
+
+}  // namespace jxl
+
+#endif  // ENCODER_READ_PFM_H_

--- a/lib/extras/enc/pnm.cc
+++ b/lib/extras/enc/pnm.cc
@@ -149,7 +149,7 @@ class PFMEncoder : public PNMEncoder {
     std::vector<JxlPixelFormat> formats;
     for (const uint32_t num_channels : {1, 3}) {
       for (const JxlDataType data_type : {JXL_TYPE_FLOAT16, JXL_TYPE_FLOAT}) {
-        for (JxlEndianness endianness : {JXL_BIG_ENDIAN, JXL_LITTLE_ENDIAN}) {
+        for (JxlEndianness endianness : {JXL_LITTLE_ENDIAN, JXL_BIG_ENDIAN}) {
           formats.push_back(JxlPixelFormat{/*num_channels=*/num_channels,
                                            /*data_type=*/data_type,
                                            /*endianness=*/endianness,

--- a/lib/jxl/enc_file.h
+++ b/lib/jxl/enc_file.h
@@ -36,17 +36,8 @@ Status EncodeFile(const CompressParams& params, const CodecInOut* io,
                   PaddedBytes* compressed, const JxlCmsInterface& cms,
                   AuxOut* aux_out = nullptr, ThreadPool* pool = nullptr);
 
-// Backwards-compatible interface. Don't use in new code.
-// TODO(deymo): Remove this function once we migrate users to C encoder API.
-struct FrameEncCache {};
-JXL_INLINE Status EncodeFile(const CompressParams& params, const CodecInOut* io,
-                             FrameEncCache* /* unused */,
-                             PaddedBytes* compressed,
-                             const JxlCmsInterface& cms,
-                             AuxOut* aux_out = nullptr,
-                             ThreadPool* pool = nullptr) {
-  return EncodeFile(params, io, compressed, cms, aux_out, pool);
-}
+Status EncodeFile(const Image3F& input, float distance,
+                  std::vector<uint8_t>* output);
 
 }  // namespace jxl
 


### PR DESCRIPTION
For testing add a binary that reads a pfm and calls the simple
version of the encoder, plus add a benchmark flag that calls the
simple encoder.

Add a new encoder/ subdirectory where the source files needed for
the simple encoder will be copied.