### PR TITLE
Add a compile-time option for a prefix code optimization stage.

### DIFF
--- a/encoder/config.h
+++ b/encoder/config.h
@@ -1,0 +1,12 @@
+// Copyright (c) the JPEG XL Project Authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef ENCODER_CONFIG_H_
+#define ENCODER_CONFIG_H_
+
+#define OPTIMIZE_CODE 1
+
+#endif  // ENCODER_CONFIG_H_

--- a/encoder/enc_cluster.cc
+++ b/encoder/enc_cluster.cc
@@ -7,13 +7,8 @@
 #include "encoder/enc_cluster.h"
 
 #include <algorithm>
-#include <cmath>
 #include <limits>
 #include <map>
-#include <memory>
-#include <numeric>
-#include <queue>
-#include <tuple>
 
 #include "encoder/enc_huffman_tree.h"
 
@@ -23,7 +18,7 @@ namespace {
 void HistogramBitCost(const Histogram& a) {
   a.bit_cost = 0;
   if (a.total_count == 0) return;
-  uint8_t depths[kAlphabetSize];
+  uint8_t depths[kAlphabetSize] = {};
   CreateHuffmanTree(a.counts, kAlphabetSize, 15, depths);
   for (size_t i = 0; i < kAlphabetSize; ++i) {
     a.bit_cost += a.counts[i] * depths[i];
@@ -70,7 +65,8 @@ void FastClusterHistograms(const std::vector<Histogram>& in,
     largest_idx = 0;
     for (size_t i = 0; i < in.size(); i++) {
       if (dists[i] == 0.0f) continue;
-      dists[i] = std::min(HistogramDistance(in[i], out->back()), dists[i]);
+      float dist = HistogramDistance(in[i], out->back());
+      dists[i] = std::min(dist, dists[i]);
       if (dists[i] > dists[largest_idx]) largest_idx = i;
     }
     if (dists[largest_idx] < kMinDistanceForDistinct) break;

--- a/encoder/enc_entropy_code.h
+++ b/encoder/enc_entropy_code.h
@@ -12,6 +12,7 @@
 
 #include "encoder/enc_bit_writer.h"
 #include "encoder/entropy_code.h"
+#include "encoder/histogram.h"
 #include "encoder/token.h"
 
 namespace jxl {
@@ -20,19 +21,22 @@ void OptimizePrefixCodes(const std::vector<Token>& tokens, EntropyCode* code);
 
 void OptimizeEntropyCode(const std::vector<Token>& tokens, EntropyCode* code);
 
+void OptimizeEntropyCode(std::vector<Histogram>* histograms, EntropyCode* code);
+
 void WriteEntropyCode(const EntropyCode& code, BitWriter* writer);
+
+// This is an upper bound on the average bits per token on an array of
+// at most 256x256 entropy coded tokens.
+static constexpr size_t kMaxBitsPerToken = 24;
 
 static inline void WriteToken(const Token& token, const EntropyCode& code,
                               BitWriter* writer) {
-  // TODO(szabadka) Move this out of here.
-  BitWriter::Allotment allotment(writer, 32);
   uint32_t tok, nbits, bits;
   UintCoder().Encode(token.value, &tok, &nbits, &bits);
   const PrefixCode& pc = code.prefix_codes[code.context_map[token.context]];
   uint64_t data = pc.bits[tok];
   data |= bits << pc.depths[tok];
   writer->Write(pc.depths[tok] + nbits, data);
-  allotment.Reclaim(writer);
 }
 
 }  // namespace jxl

--- a/encoder/entropy_code.h
+++ b/encoder/entropy_code.h
@@ -14,6 +14,7 @@
 namespace jxl {
 
 static constexpr size_t kAlphabetSize = 64;
+static constexpr uint8_t kMaxContexts = 128;
 
 struct PrefixCode {
   uint8_t depths[kAlphabetSize];
@@ -34,6 +35,9 @@ struct EntropyCode {
   // Data storage for the optimized entropy codes.
   std::vector<uint8_t> context_map_storage;
   std::vector<PrefixCode> prefix_code_storage;
+  // Original context map, in case the contexts were clustered.
+  const uint8_t* orig_context_map = nullptr;
+  size_t orig_num_contexts = 0;
 };
 
 }  // namespace jxl

--- a/encoder/histogram.h
+++ b/encoder/histogram.h
@@ -20,7 +20,10 @@ struct Histogram {
     memset(counts, 0, sizeof(counts));
     total_count = 0;
   }
-  void Add(uint32_t symbol) { counts[symbol]++; }
+  void Add(uint32_t symbol) {
+    ++counts[symbol];
+    ++total_count;
+  }
   void AddHistogram(const Histogram& other) {
     for (size_t i = 0; i < kAlphabetSize; ++i) {
       counts[i] += other.counts[i];

--- a/encoder/static_entropy_codes.h
+++ b/encoder/static_entropy_codes.h
@@ -13,9 +13,8 @@
 
 namespace jxl {
 
-static constexpr uint8_t kContextTreeContextMap[] = {0, 1, 2, 1, 1, 1};
-static constexpr size_t kNumContextTreePrefixCodes = 3;
-
+// TODO(szabaka) Create context maps with more histograms for the
+// OPTIMIZE_CODE case.
 static constexpr uint8_t kDCContextMap[] = {
     0, 1, 2, 2, 1, 1, 3, 0, 3, 0, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6,
     6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 6, 7, 6, 7, 6, 6, 5, 5,


### PR DESCRIPTION
This stage is after the tile-processing and before the final bitstream assembly.

The tile processors work the same way, but write (context, value) pairs encoded in 24 bits instead of the entropy coded tokens.

The optimization stage reads back these section-by-section, builds histograms, does clustering and Huffman code building and then rewrites the bitstream with the optimized codes section-by-section.