### PR TITLE
Fix final bitstream assembly for small images.

### DIFF
--- a/encoder/enc_bit_writer.h
+++ b/encoder/enc_bit_writer.h
@@ -62,6 +62,7 @@ struct BitWriter {
   }
 
  public:
+  void Append(const BitWriter& other);
   void AppendByteAligned(std::vector<BitWriter>* others);
 
   class Allotment {

--- a/encoder/enc_frame.cc
+++ b/encoder/enc_frame.cc
@@ -802,7 +802,13 @@ void OptimizeSections(EntropyCode* code, BitWriter* sections, size_t num) {
 #endif
 
 void CombineSections(std::vector<BitWriter>* sections, BitWriter* writer) {
-  // TODO(szabadka) Fix this for small images.
+  if (sections->size() == 4) {
+    // If we have only one AC group, everything must be put into one section.
+    for (size_t i = 1; i < 4; ++i) {
+      (*sections)[0].Append((*sections)[i]);
+    }
+    sections->resize(1);
+  }
   WriteTOC(*sections, writer);
   writer->AppendByteAligned(sections);
 }

--- a/encoder/static_entropy_codes.h
+++ b/encoder/static_entropy_codes.h
@@ -160,7 +160,7 @@ static constexpr PrefixCode kDCPrefixCodes[kNumDCPrefixCodes] = {
 #if OPTIMIZE_CODE
 static constexpr size_t kNumACPrefixCodes = 64;
 static constexpr const PrefixCode* kACPrefixCodes = nullptr;
-// TODO(szabaka) Make the context map dependent on the distance setting.
+// TODO(szabadka) Make the context map dependent on the distance setting.
 /* clang-format off */
 static constexpr uint8_t kACContextMap[] = {
     // Context map for number of nonzeros


### PR DESCRIPTION
If the image is smaller than 256x256 pixels, there can be only one section in the TOC instead of 4.